### PR TITLE
Bytecode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,5 @@ app/Main
 *.blg
 *.bbl
 compiladores.cabal
+*.byte
 

--- a/package.yaml
+++ b/package.yaml
@@ -26,7 +26,9 @@ dependencies:
 - pretty
 - mtl
 - exceptions
-
+- binary
+- bytestring
+- optparse-applicative
 
 library:
   source-dirs: src

--- a/src/Bytecompile.hs
+++ b/src/Bytecompile.hs
@@ -16,7 +16,7 @@ module Bytecompile
 import Lang 
 import Subst
 import MonadPCF
-import Elab (desugarDecl, elab')
+import Elab (elab)
 
 import qualified Data.ByteString.Lazy as BS
 import Data.Binary ( Word32, Binary(put, get), decode, encode )
@@ -89,16 +89,11 @@ bc (Let _ f ty t1 t2)  = do bt1 <- bc t1
                             bt2 <- bc t2
                             return (bt1 ++ [SHIFT] ++ bt2 ++ [DROP])
 
-bytecompileModule :: MonadPCF m => [SDecl SNTerm] -> m Bytecode
-bytecompileModule [] = return []
-bytecompileModule (sd:decls) = do
-                d <- desugarDecl sd
-                let Decl _ _ body = d
-                let term = elab' body
-                bytecode <- bc term
-                printPCF ("El Term es " ++ show(term) ++ "y su bytecode es " ++ show(bytecode))
-                bytecodes <- bytecompileModule decls
-                return (bytecode ++ bytecodes)
+bytecompileModule :: MonadPCF m => SNTerm -> m Bytecode
+bytecompileModule st = do
+                t <- elab st
+                bytecode <- bc t
+                return bytecode
 
 -- | Toma un bytecode, lo codifica y lo escribe un archivo 
 bcWrite :: Bytecode -> FilePath -> IO ()

--- a/src/Bytecompile.hs
+++ b/src/Bytecompile.hs
@@ -145,4 +145,4 @@ runBC' (DROP: cs) (_:e) s  = runBC' cs e s
 runBC' (PRINT: cs) e (n:s) = do
                   printPCF ("El valor en el stack es: " ++ show(n))
                   runBC' cs e (n:s)
-runBC' cs _ _ = printPCF ("Error en Compilación a Bytecode " ++ show(cs))
+runBC' _ _ _ = do failPCF $ "Error en Ejecución a Bytecode "

--- a/src/Bytecompile.hs
+++ b/src/Bytecompile.hs
@@ -1,0 +1,87 @@
+{-# LANGUAGE PatternSynonyms #-}
+{-|
+Module      : Bytecompile
+Description : Compila a bytecode. Ejecuta bytecode.
+Copyright   : (c) Mauro Jaskelioff, Guido Martínez, 2020.
+License     : GPL-3
+Maintainer  : mauro@fceia.unr.edu.ar
+Stability   : experimental
+Este módulo permite compilar módulos a la BVM. También provee una implementación de la BVM 
+para ejecutar bytecode.
+-}
+module Bytecompile
+  (Bytecode, bytecompileModule, runBC, bcWrite, bcRead)
+ where
+
+import Lang 
+import Subst
+import MonadPCF
+
+import qualified Data.ByteString.Lazy as BS
+import Data.Binary ( Word32, Binary(put, get), decode, encode )
+import Data.Binary.Put ( putWord32le )
+import Data.Binary.Get ( getWord32le, isEmpty )
+type Opcode = Int
+type Bytecode = [Int]
+
+newtype Bytecode32 = BC { un32 :: [Word32] }
+
+{- Esta instancia explica como codificar y decodificar Bytecode de 32 bits -}
+instance Binary Bytecode32 where
+  put (BC bs) = mapM_ putWord32le bs
+  get = go 
+    where go =  
+           do
+            empty <- isEmpty
+            if empty
+              then return $ BC []
+              else do x <- getWord32le
+                      BC xs <- go
+                      return $ BC (x:xs)
+
+{- Estos sinónimos de patrón nos permiten escribir y hacer
+pattern-matching sobre el nombre de la operación en lugar del código
+entero, por ejemplo:
+ 
+   f (CALL : cs) = ...
+ Notar que si hubieramos escrito algo como
+   call = 5
+ no podríamos hacer pattern-matching con `call`.
+ En lo posible, usar estos códigos exactos para poder ejectutar un
+ mismo bytecode compilado en distintas implementaciones de la máquina.
+-}
+pattern RETURN   = 1
+pattern CONST    = 2
+pattern ACCESS   = 3
+pattern FUNCTION = 4
+pattern CALL     = 5
+pattern SUCC     = 6
+pattern PRED     = 7
+pattern IFZ      = 8
+pattern FIX      = 9
+pattern STOP     = 10
+pattern JUMP     = 11
+pattern SHIFT    = 12
+pattern DROP     = 13
+pattern PRINT    = 14
+
+bc :: MonadPCF m => Term -> m Bytecode
+bc t = error "implementame"
+
+bytecompileModule :: MonadPCF m => [Decl Term] -> m Bytecode
+bytecompileModule mod = error "implementame"
+
+-- | Toma un bytecode, lo codifica y lo escribe un archivo 
+bcWrite :: Bytecode -> FilePath -> IO ()
+bcWrite bs filename = BS.writeFile filename (encode $ BC $ fromIntegral <$> bs)
+
+---------------------------
+-- * Ejecución de bytecode
+---------------------------
+
+-- | Lee de un archivo y lo decodifica a bytecode
+bcRead :: FilePath -> IO Bytecode
+bcRead filename = map fromIntegral <$> un32  <$> decode <$> BS.readFile filename
+
+runBC :: MonadPCF m => Bytecode -> m ()
+runBC c = error "implementame"

--- a/src/Bytecompile.hs
+++ b/src/Bytecompile.hs
@@ -85,6 +85,9 @@ bc (IfZ _ c t f)       = do btc <- bc c
                             btf <- bc f
                             let args = [IFZ] ++ (length btt: btt) ++ (length btf: btf)
                             return ([FUNCTION, length args + 1] ++ args ++ [RETURN] ++ btc ++ [CALL])
+bc (Let _ f ty t1 t2)  = do bt1 <- bc t1
+                            bt2 <- bc t2
+                            return (bt1 ++ [SHIFT] ++ bt2 ++ [DROP])
 
 bytecompileModule :: MonadPCF m => [SDecl SNTerm] -> m Bytecode
 bytecompileModule [] = return []
@@ -147,4 +150,4 @@ runBC' (DROP: cs) (_:e) s  = runBC' cs e s
 runBC' (PRINT: cs) e (n:s) = do
                   printPCF ("El valor en el stack es: " ++ show(n))
                   runBC' cs e (n:s)
-runBC' cs _ _ = printPCF ("SALIO MAL " ++ show(cs))
+runBC' cs _ _ = printPCF ("Error en Compilación a Bytecode " ++ show(cs))

--- a/src/CEK.hs
+++ b/src/CEK.hs
@@ -26,6 +26,7 @@ data Val =
 data Clos =
       CFun Env Name Ty Term
     | CFix Env Name Ty Name Ty Term 
+    | CLet Env Name Ty Term Term 
     deriving (Show)
 
 -- | Entorno
@@ -42,7 +43,8 @@ data Frames =
     | KClos Clos
     | KIf Env Term Term
     | KSucc 
-    | KPred 
+    | KPred
+    | KLet Env Term
     deriving (Show)
 
 -- | Continuaciones
@@ -62,6 +64,7 @@ search (V _ (Free v)) e k     = do
 search (Const _ (CNat c)) _ k     = destroy (N c) k
 search (Lam _ x xty t) e k        = destroy (Clos (CFun e x xty t)) k
 search (Fix _ f fty x xty t) e k  = destroy (Clos (CFix e f fty x xty t)) k
+search (Let _ f fty t1 t2) e k    = search t1 e ((KLet e t2):k)
 
 destroy :: MonadPCF m => Val -> Kont -> m Val
 destroy v []                                 = return v
@@ -73,6 +76,7 @@ destroy (N _) ((KIf e _ f):k)                = search f e k
 destroy (Clos c) ((KArg e t):k)              = search t e ((KClos c):k)
 destroy v ((KClos (CFun e _ _ t):k))         = search t (v:e) k
 destroy v ((KClos (CFix e f fty x xty t)):k) = search t (v:(Clos (CFix e f fty x xty t)):e) k
+destroy v ((KLet e t):k)                     = search t (v:e) k
 destroy _ _ = failPCF $ "Fallo de evaluacion en el destroy"
 
 

--- a/src/Common.hs
+++ b/src/Common.hs
@@ -39,3 +39,14 @@ abort s = error ("INTERNAL ERROR: " ++ s)
 infixl 1 |>
 (|>) :: a -> (a -> b) -> b
 x |> f = f x
+
+-- wordsWhen     :: (Char -> Bool) -> String -> [String]
+-- wordsWhen p s =  case dropWhile p s of
+--                       "" -> []
+--                       s' -> w : wordsWhen p s''
+--                             where (w, s'') = break p s'
+
+dropExtension :: String -> String
+dropExtension (x:xs) = case x of
+                        '.' -> []
+                        _   -> x: (dropExtension xs)

--- a/src/Lang.hs
+++ b/src/Lang.hs
@@ -67,6 +67,7 @@ data Tm info var =
   | UnaryOp info UnaryOp (Tm info var)
   | Fix info Name Ty Name Ty (Tm info var)
   | IfZ info (Tm info var) (Tm info var) (Tm info var)
+  | Let info Name Ty (Tm info var) (Tm info var)
   deriving (Show, Functor)
 
 type NTerm = Tm Pos Name   -- ^ 'Tm' tiene 'Name's como variables ligadas y libres, guarda posición

--- a/src/Parse.hs
+++ b/src/Parse.hs
@@ -139,12 +139,6 @@ ifz = do i <- getPos
          e <- stm
          return (SIfZ i c t e)
 
--- binding :: P (Name, STy)
--- binding = do v <- var
---              reservedOp ":"
---              ty <- typeP
---              return (v, ty)
-
 binding :: P [(Name, STy)]
 binding = do vs <- many1 var
              reservedOp ":"
@@ -152,7 +146,6 @@ binding = do vs <- many1 var
              return (fmap (\v -> (v,ty)) vs)
 
 binders :: P [(Name, STy)]
--- binders = concat (many (parens binding)) <|> return []
 binders = do vs <- many (parens binding)
              return (concat vs)
           <|> return []

--- a/src/Subst.hs
+++ b/src/Subst.hs
@@ -30,7 +30,7 @@ varChanger local bound t = go 0 t where
   go n (IfZ p c t e) = IfZ p (go n c) (go n t) (go n e)
   go n t@(Const _ _) = t
   go n (UnaryOp p op t) = UnaryOp p op (go n t)
-  go n (Let p f ty t1 t2) = Let p f ty (go n t1) (go n t2)
+  go n (Let p f ty t1 t2) = Let p f ty (go n t1) (go (n+1) t2)
 
 -- `openN [nn,..,n0] t` reemplaza las primeras (n+1) variables ligadas
 -- en `t` (que debe ser localmente cerrado) por los nombres libres en la

--- a/src/Subst.hs
+++ b/src/Subst.hs
@@ -30,6 +30,7 @@ varChanger local bound t = go 0 t where
   go n (IfZ p c t e) = IfZ p (go n c) (go n t) (go n e)
   go n t@(Const _ _) = t
   go n (UnaryOp p op t) = UnaryOp p op (go n t)
+  go n (Let p f ty t1 t2) = Let p f ty (go n t1) (go n t2)
 
 -- `openN [nn,..,n0] t` reemplaza las primeras (n+1) variables ligadas
 -- en `t` (que debe ser localmente cerrado) por los nombres libres en la

--- a/src/TypeChecker.hs
+++ b/src/TypeChecker.hs
@@ -57,6 +57,11 @@ tc (Fix p f fty x xty t) bs = do
          ty' <- tc t' ((x,xty):(f,fty):bs)
          expect cod ty' t'
          return fty
+tc (Let _ f ty t1 t2) bs = do
+         ty1 <- tc t1 bs
+         expect ty ty1 t1
+         ty2 <- tc (open f t2) ((f,ty):bs)
+         return ty2
 
 -- | @'typeError' t s@ lanza un error de tipo para el término @t@ 
 typeError :: MonadPCF m => Term   -- ^ término que se está chequeando  


### PR DESCRIPTION
1.  Implementar la compilación a bytecode y máquina virtual en Haskell, usando el esqueleto provisto. La instrucción PRINT debe imprimir a la consola, por lo que la función que ejecuta la máquina debe estar en MonadPCF. 
2. Proponer e implementar un esquema de compilación y ejecución para ifz. Pueden agregarse nuevas instrucciones a la máquina.
3. Implementar let-bindings internos, y asegurarse de que se compilen de manera eficiente